### PR TITLE
Fix hero model memory allocation

### DIFF
--- a/base_interface.hpp
+++ b/base_interface.hpp
@@ -197,10 +197,11 @@ void showBody(Body* c)
 
     puts("test");
 
-    for (cont = 0;cont < c->gettamanho()/*tam*/;cont++)
+    const vector<Ellipsoid>& parts = c->getbolas();
+    for (cont = 0; cont < c->gettamanho(); cont++)
     {
         puts("calling displayEllipsoid");
-        showEllipsoid(c->getbolas().at(cont));
+        showEllipsoid(parts.at(cont));
     }
 }
 

--- a/classes.cpp
+++ b/classes.cpp
@@ -120,7 +120,7 @@ Body::Body(string s)
 }
 
 
-vector<Ellipsoid> Body::getbolas()
+const vector<Ellipsoid>& Body::getbolas() const
 {
     return bolas;
 }

--- a/classes.hpp
+++ b/classes.hpp
@@ -40,7 +40,7 @@ public:
     Body(vector<Ellipsoid>,int);
     Body(string);
     void testaBody();
-    vector<Ellipsoid> getbolas();
+    const vector<Ellipsoid>& getbolas() const;
     int gettamanho();
 
     Ellipsoid elip(string);

--- a/map_logic.hpp
+++ b/map_logic.hpp
@@ -88,7 +88,7 @@ void analyzeContent(int a,int b,int c,int *d){
     }
     arquivo[*d] = '\0';
     *d=*d+1;
-    gameMap[b][c].conteudo=(char*) malloc(strlen(arquivo));
+    gameMap[b][c].conteudo=(char*) malloc(strlen(arquivo) + 1);
     strcpy(gameMap[b][c].conteudo,arquivo);
 }
 


### PR DESCRIPTION
## Summary
- ensure `conteudo` strings include space for the null terminator
- avoid copying vectors when displaying models

## Testing
- `make termak3d`

------
https://chatgpt.com/codex/tasks/task_e_685b4cff85d8832eb61dc522fdf8c76c