### PR TITLE
Switch to first-person camera

### DIFF
--- a/base_interface.hpp
+++ b/base_interface.hpp
@@ -25,7 +25,7 @@
 #define LARGE_HP 20
 
 
-double xobs = 0,yobs = 100,zobs = 0;
+double xobs = 0,yobs = 10,zobs = 0;
 
 double alfax = 0;
 double alfay = 0;
@@ -42,7 +42,7 @@ void resetCamera(){
     alfax = 0;
     alfay = 0;
     alfaz = 0;
-    yobs = 100;
+    yobs = 10;
 }
 
 void habzbuffer(){

--- a/battle_interface.hpp
+++ b/battle_interface.hpp
@@ -111,7 +111,7 @@ void show_battle()
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     gluPerspective(80,1,0.05,200);
-    gluLookAt(xobs,yobs,zobs,0,0,0,1,0,0);
+    gluLookAt(heroX,heroY + yobs,heroZ,heroX,heroY + yobs,heroZ - 20,0,1,0);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
     glRotatef(alfax,1,0,0);

--- a/map_interface.hpp
+++ b/map_interface.hpp
@@ -72,15 +72,27 @@ inline void show_map(){
     glClearColor(0,0,0.5,1);
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
+
+    double hx = chero * DIMCASA;
+    double hz = lhero * DIMCASA;
+    double hy = yobs;
+
+    double tx = hx;
+    double ty = hy;
+    double tz = hz;
+
+    switch(gameMap[lhero][chero].orientacao){
+        case RIGHT: tx += DIMCASA; break;
+        case LEFT:  tx -= DIMCASA; break;
+        case UP:    tz -= DIMCASA; break;
+        case DOWN:  tz += DIMCASA; break;
+    }
+
     gluPerspective(80,1,0.05,200);
-    gluLookAt(xobs,yobs,zobs,0,0,0,1,0,0);
+    gluLookAt(hx,hy,hz,tx,ty,tz,0,1,0);
 
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
-    glRotatef(-90,0,1,0);
-    glRotatef(alfax,1,0,0);
-    glRotatef(alfay,0,1,0);
-    glRotatef(alfaz,0,0,1);
 
     showMap();
     atualizamonsters();


### PR DESCRIPTION
## Summary
- default camera height is now lower
- calculate camera position based on hero coordinates in map view
- track hero position when rendering battles

## Testing
- `make termak3d` *(fails: GL/gl.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b4fecd6c8832e90cbd3a05aa514f8