### PR TITLE
Add first person toggle option

### DIFF
--- a/base_interface.hpp
+++ b/base_interface.hpp
@@ -31,6 +31,8 @@ double alfax = 0;
 double alfay = 0;
 double alfaz = 0;
 
+bool firstPerson = false;
+
 Body* heroBody;
 Body* ratBody;
 Body* catBody;
@@ -43,6 +45,10 @@ void resetCamera(){
     alfay = 0;
     alfaz = 0;
     yobs = 10;
+}
+
+void toggleFirstPerson(){
+    firstPerson = !firstPerson;
 }
 
 void habzbuffer(){

--- a/battle_interface.hpp
+++ b/battle_interface.hpp
@@ -122,7 +122,8 @@ void show_battle()
 
     glPushMatrix();
     glTranslatef(heroX,heroY,heroZ);
-    glCallList(MOD_HERO);
+    if (!firstPerson)
+        glCallList(MOD_HERO);
     glTranslatef(15,10,15);
     //glScalef(ESCALA_BARRA,ESCALA_BARRA,her -> getHP()*ESCALA_BARRA);
     showHPBar(her -> getHP());
@@ -182,6 +183,10 @@ void keyboard_battle(unsigned char tecla,int x,int y)
         break;
     case 'r':
         resetCamera();
+        break;
+    case 'p':
+        toggleFirstPerson();
+        break;
     }
 }
 

--- a/map_interface.hpp
+++ b/map_interface.hpp
@@ -19,7 +19,8 @@ inline void drawCell(const string& s){
         glCallList(modmonst);
         break;
     case 'h':
-        glCallList(MOD_HERO);
+        if (!firstPerson)
+            glCallList(MOD_HERO);
     }
     glPopMatrix();
     glTranslatef(DIMCASA,0,0);
@@ -110,6 +111,7 @@ inline void teclado_map(unsigned char tecla,int x,int y){
     case 'x': alfay--; break;
     case 'c': alfaz--; break;
     case 'r': resetCamera();
+    case 'p': toggleFirstPerson();
     }
 }
 


### PR DESCRIPTION
## Summary
- implement a `firstPerson` mode switch
- stop drawing the hero model while in first-person
- allow toggling perspective with the `p` key in map and battle modes

## Testing
- `g++ *.cpp -lglut -lGLU -lGL -o termak3d && echo compiled`
- `./termak3d` *(fails: freeglut failed to open display)*

------
https://chatgpt.com/codex/tasks/task_e_685b52fa171c832ea0d902ae772b0f59