### PR TITLE
Fix camera modes

### DIFF
--- a/base_interface.hpp
+++ b/base_interface.hpp
@@ -31,8 +31,6 @@ double alfax = 0;
 double alfay = 0;
 double alfaz = 0;
 
-bool firstPerson = false;
-
 Body* heroBody;
 Body* ratBody;
 Body* catBody;
@@ -45,10 +43,6 @@ void resetCamera(){
     alfay = 0;
     alfaz = 0;
     yobs = 10;
-}
-
-void toggleFirstPerson(){
-    firstPerson = !firstPerson;
 }
 
 void habzbuffer(){

--- a/battle_interface.hpp
+++ b/battle_interface.hpp
@@ -111,7 +111,10 @@ void show_battle()
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     gluPerspective(80,1,0.05,200);
-    gluLookAt(heroX,heroY + yobs,heroZ,heroX,heroY + yobs,heroZ - 20,0,1,0);
+    /* use a third-person camera placed behind the hero */
+    gluLookAt(heroX, heroY + yobs, heroZ + 20,
+              heroX, heroY, heroZ,
+              0, 1, 0);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
     glRotatef(alfax,1,0,0);
@@ -122,8 +125,7 @@ void show_battle()
 
     glPushMatrix();
     glTranslatef(heroX,heroY,heroZ);
-    if (!firstPerson)
-        glCallList(MOD_HERO);
+    glCallList(MOD_HERO);
     glTranslatef(15,10,15);
     //glScalef(ESCALA_BARRA,ESCALA_BARRA,her -> getHP()*ESCALA_BARRA);
     showHPBar(her -> getHP());
@@ -183,9 +185,6 @@ void keyboard_battle(unsigned char tecla,int x,int y)
         break;
     case 'r':
         resetCamera();
-        break;
-    case 'p':
-        toggleFirstPerson();
         break;
     }
 }

--- a/map_interface.hpp
+++ b/map_interface.hpp
@@ -19,8 +19,9 @@ inline void drawCell(const string& s){
         glCallList(modmonst);
         break;
     case 'h':
-        if (!firstPerson)
-            glCallList(MOD_HERO);
+        /* omit hero model in the overworld to keep the camera in
+           a first-person style */
+        break;
     }
     glPopMatrix();
     glTranslatef(DIMCASA,0,0);
@@ -111,7 +112,7 @@ inline void teclado_map(unsigned char tecla,int x,int y){
     case 'x': alfay--; break;
     case 'c': alfaz--; break;
     case 'r': resetCamera();
-    case 'p': toggleFirstPerson();
+        break;
     }
 }
 


### PR DESCRIPTION
## Summary
- remove unnecessary first-person toggle state
- hide hero model when drawing the overworld
- always render hero model in battle and use a third-person camera

## Testing
- `make termak3d` *(fails: GL/gl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c39874800832e8b967303fee65376