### PR TITLE
Fix battle monster pointer handling

### DIFF
--- a/battle_interface.hpp
+++ b/battle_interface.hpp
@@ -5,6 +5,8 @@
 #define INTERFACEBAT
 
 #include <math.h>
+#include <cctype>
+#include <string>
 
 #define LIML 0
 #define LIMU 75
@@ -21,7 +23,7 @@ double heroX,heroY,heroZ;
 double monsterX,monsterY,monsterZ;
 
 Fighter* her = new Fighter(15,10,10,5,666);
-Fighter* monst;
+Fighter* monst = nullptr;
 
 
 
@@ -31,16 +33,17 @@ void checkBattleEnd(){
         exit(0);
     }
 
-    if (monst -> getHP() <= 0){
-        if (monst -> getid() == CAT){
+    if (monst && monst->getHP() <= 0){
+        if (monst->getid() == CAT){
             cout << "THE END" << endl;
             exit(0);
         }
 
         resetCamera();
         cout << "HP = " << her -> getHP() << endl;
-
         modo = MAP;
+        delete monst;
+        monst = nullptr;
         return;
     }
 }
@@ -52,25 +55,30 @@ void showEnemy(){
     }
     else glCallList(MOD_RAT);*/
 
-    switch(monst -> getid())
+    if (!monst) return;
+    switch(monst->getid())
     {
-	case CAT: glCallList(MOD_CAT);
-		   break;
-	case RAT: glCallList(MOD_RAT);
-		   break;
-	case SCORPION: glCallList(MOD_SCORPION);
+        case CAT: glCallList(MOD_CAT);
+                   break;
+        case RAT: glCallList(MOD_RAT);
+                   break;
+        case SCORPION: glCallList(MOD_SCORPION);
+                   break;
+        default: break;
     }
 }
 
 
 void moveMonster()
 {
+    if (!monst) return;
+
     int dir = rand() % 4;
     double novox = monsterX;
     double novoz = monsterZ;
     double xalvo = heroX;
     double zalvo = heroZ;
-    double rangeVar = monst -> getRange()*STEP;
+    double rangeVar = monst->getRange()*STEP;
 
     //if (monst -> getid() == CAT) rangeVar = 10*STEP;
 
@@ -131,14 +139,16 @@ void show_battle()
     showHPBar(her -> getHP());
     glPopMatrix();
 
-    glPushMatrix();
-    glTranslatef(monsterX,monsterY,monsterZ);
-    showEnemy();
-    glTranslatef(15,10,15);
-    //if(monst -> getid() == CAT) glTranslatef(0,15,-15);
-    //glScalef(ESCALA_BARRA,ESCALA_BARRA,monst -> getHP()*ESCALA_BARRA);
-    showHPBar(monst -> getHP());
-    glPopMatrix();
+    if (monst){
+        glPushMatrix();
+        glTranslatef(monsterX,monsterY,monsterZ);
+        showEnemy();
+        glTranslatef(15,10,15);
+        //if(monst -> getid() == CAT) glTranslatef(0,15,-15);
+        //glScalef(ESCALA_BARRA,ESCALA_BARRA,monst -> getHP()*ESCALA_BARRA);
+        showHPBar(monst->getHP());
+        glPopMatrix();
+    }
     glutSwapBuffers();
 
     moveMonster();
@@ -146,6 +156,8 @@ void show_battle()
 
 void keyboard_battle(unsigned char tecla,int x,int y)
 {
+
+    if (!monst) return;
 
     double xalvo = monsterX;
     double zalvo = monsterZ;
@@ -193,13 +205,15 @@ void arrows_battle(int seta,int x,int y)
 {
     x = y;
 
+    if (!monst) return;
+
     double xalvo = monsterX;
     double zalvo = monsterZ;
     double novox = heroX;
     double novoz = heroZ;
     double rangeVar = STEP;
 
-    if (monst -> getid() == CAT) rangeVar = 3*STEP;
+    if (monst->getid() == CAT) rangeVar = 3*STEP;
 
     if (!(TESTEX && TESTEZ))
     {

--- a/map_logic.hpp
+++ b/map_logic.hpp
@@ -1,4 +1,7 @@
 #include <time.h>
+#include <string>
+#include <cstring>
+#include <cctype>
 
 #define UP 3
 #define DOWN 1
@@ -212,14 +215,23 @@ void battle(char* a){
         monst = new Fighter(15,10,50,RAT);
     }*/
 
-    switch(a[0])
-    {
-	case 'g': monst = new Fighter(100,10,50,10,CAT);
-		  break;
-	case 'r': monst = new Fighter(15,10,50,3,RAT);
-                  break;
-	case 'e': monst = new Fighter(15,20,50,4,SCORPION);
-        default: break;
+    if (monst){
+        delete monst;
+        monst = nullptr;
+    }
+
+    std::string name = a ? std::string(a) : "";
+    if (!name.empty()) name[0] = std::tolower(name[0]);
+
+    if (name.size() && (name[0] == 'c' || name[0] == 'g')){
+        monst = new Fighter(100,10,50,10,CAT);
+    } else if (name.size() && name[0] == 'r'){
+        monst = new Fighter(15,10,50,3,RAT);
+    } else if (name.size() && (name[0] == 's' || name[0] == 'e')){
+        monst = new Fighter(15,20,50,4,SCORPION);
+    } else {
+        fprintf(stderr, "Unknown monster '%s', defaulting to rat\n", a);
+        monst = new Fighter(15,10,50,3,RAT);
     }
 
     printf("HP = %f\n",her -> getHP());


### PR DESCRIPTION
## Summary
- prevent crashes when monster pointer is null
- free monster memory when the battle ends
- handle unknown monster names in `battle()`
- include missing headers for string parsing

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y freeglut3-dev`
- `make termak3d`

------
https://chatgpt.com/codex/tasks/task_e_685c3bbeb8b8832eaf1e735970190397