### PR TITLE
Enable fullscreen mode with dynamic aspect ratio

### DIFF
--- a/battle_interface.hpp
+++ b/battle_interface.hpp
@@ -120,7 +120,10 @@ void show_battle()
     glClearColor(0,0,0,1);
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    gluPerspective(80,1,0.05,200);
+    int width = glutGet(GLUT_WINDOW_WIDTH);
+    int height = glutGet(GLUT_WINDOW_HEIGHT);
+    double aspect = width / (double) height;
+    gluPerspective(80,aspect,0.05,200);
     /* top-down camera centered on the battle field */
     gluLookAt(BATTLE_CENTER, BATTLE_CAM_HEIGHT + yobs, BATTLE_CENTER,
               BATTLE_CENTER, 0, BATTLE_CENTER,

--- a/main.cpp
+++ b/main.cpp
@@ -86,8 +86,11 @@ void initGlut(int* a,char** b)
     glutInit(a,b);
     glutInitDisplayMode(GLUT_DOUBLE | GLUT_DEPTH | GLUT_RGB);
     glutInitWindowPosition(0,0);
-    glutInitWindowSize(500,500);
+    int width = glutGet(GLUT_SCREEN_WIDTH);
+    int height = glutGet(GLUT_SCREEN_HEIGHT);
+    glutInitWindowSize(width, height);
     glutCreateWindow("Termak 3D");
+    glutFullScreen();
     glutDisplayFunc(display);
     glutKeyboardFunc(keyboard);
     glutMouseFunc(mouse);

--- a/map_interface.hpp
+++ b/map_interface.hpp
@@ -90,7 +90,10 @@ inline void show_map(){
         case DOWN:  tz += DIMCASA; break;
     }
 
-    gluPerspective(80,1,0.05,200);
+    int width = glutGet(GLUT_WINDOW_WIDTH);
+    int height = glutGet(GLUT_WINDOW_HEIGHT);
+    double aspect = width / (double) height;
+    gluPerspective(80,aspect,0.05,200);
     gluLookAt(hx,hy,hz,tx,ty,tz,0,1,0);
 
     glMatrixMode(GL_MODELVIEW);


### PR DESCRIPTION
## Summary
- make the GLUT window full screen using the device resolution
- update perspective calculations in map and battle modes to use the current window size

## Testing
- `make clean && make termak3d`

------
https://chatgpt.com/codex/tasks/task_e_685c5131c54c832eaa0745d1179d1449